### PR TITLE
SearchProcessor fixes and improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,7 @@
         "rollerworks/search-processor": "^0.2.0",
         "rollerworks/search": "^2.0,>=2.0.0-ALPHA2",
         "rollerworks/uri-encoder": "^1.1.0",
-        "api-platform/core": "^2.0.3",
-        "symfony/psr-http-message-bridge": "^1.0.0",
-        "zendframework/zend-diactoros": "^1.3.9"
+        "api-platform/core": "^2.0.3"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.2.6",

--- a/src/Processor/ApiSearchProcessor.php
+++ b/src/Processor/ApiSearchProcessor.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform\Processor;
+
+use Psr\SimpleCache\CacheInterface as Cache;
+use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
+use Rollerworks\Component\Search\Loader\ConditionExporterLoader;
+use Rollerworks\Component\Search\Loader\InputProcessorLoader;
+use Rollerworks\Component\Search\Processor\ProcessorConfig;
+use Rollerworks\Component\Search\Processor\SearchPayload;
+use Rollerworks\Component\Search\Processor\SearchProcessor;
+use Rollerworks\Component\Search\SearchFactory;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Psr7SearchProcessor handles a search provided with a PSR-7 ServerRequest.
+ *
+ * SearchProcessor processes search-data.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class ApiSearchProcessor implements SearchProcessor
+{
+    private $searchFactory;
+    private $inputFactory;
+    private $exportFactory;
+    private $cache;
+
+    public function __construct(SearchFactory $searchFactory, InputProcessorLoader $inputFactory, ConditionExporterLoader $exportFactory, Cache $cache = null)
+    {
+        $this->searchFactory = $searchFactory;
+        $this->inputFactory = $inputFactory;
+        $this->exportFactory = $exportFactory;
+        $this->cache = $cache ?? new NullCache();
+    }
+
+    /**
+     * Process the request for a search operation.
+     *
+     * @param Request         $request The HttpFoundation Request to extract information from
+     * @param ProcessorConfig $config  Input processor configuration
+     *
+     * @return SearchPayload The SearchPayload contains READ-ONLY information about
+     *                       the processing
+     */
+    public function processRequest($request, ProcessorConfig $config): SearchPayload
+    {
+        if (!$request instanceof Request) {
+            throw new UnexpectedTypeException($request, Request::class);
+        }
+
+        $input = $request->query->get('search', []);
+        $payload = $this->processInput($config, $input);
+
+        if (!$payload->changed && !empty($input) && $input !== $payload->exportedCondition) {
+            $payload->changed = true;
+        }
+
+        return $payload;
+    }
+
+    private function processInput(ProcessorConfig $config, $input): SearchPayload
+    {
+        $payload = new SearchPayload();
+        $payload->searchCode = '';
+
+        if (!is_array($input) || [] === $input) {
+            return $payload;
+        }
+
+        if (null !== $cachedPayload = $this->fetchCached($config, $input)) {
+            return $cachedPayload;
+        }
+
+        $payload->searchCondition = $this->inputFactory->get('array')->process($config, $input);
+        $this->searchFactory->optimizeCondition($payload->searchCondition);
+
+        $this->exportCondition($payload);
+        $this->storeCache($config, $payload);
+
+        return $payload;
+    }
+
+    private function fetchCached(ProcessorConfig $config, $input): ?SearchPayload
+    {
+        $cacheKey = $this->getConditionCacheKey($config, json_encode($input));
+
+        if (null !== $payload = $this->cache->get($cacheKey)) {
+            try {
+                $payload->searchCondition = $this->searchFactory->getSerializer()->unserialize($payload->searchCondition);
+            } catch (\Exception $e) {
+                $this->cache->delete($cacheKey);
+                $payload = null;
+            }
+        }
+
+        return $payload;
+    }
+
+    private function exportCondition(SearchPayload $payload)
+    {
+        if (null === $payload->searchCondition) {
+            return;
+        }
+
+        $exported = $this->exportFactory->get('array')->exportCondition($payload->searchCondition);
+        $payload->searchCode = http_build_query($exported);
+        $payload->exportedCondition = $exported;
+        $payload->exportedFormat = 'array';
+    }
+
+    private function storeCache(ProcessorConfig $config, SearchPayload $payload)
+    {
+        if ([] === $payload->exportedCondition) {
+            return;
+        }
+
+        // Store the SearchCondition in the custom serialized format to allow deserialization later-on.
+        $payload = clone $payload;
+        $payload->changed = false;
+        $payload->searchCondition = $this->searchFactory->getSerializer()->serialize($payload->searchCondition);
+
+        $this->cache->set(
+            $this->getConditionCacheKey($config, json_encode($payload->exportedCondition)),
+            $payload,
+            $config->getCacheTTL()
+        );
+    }
+
+    private function getConditionCacheKey(ProcessorConfig $config, string $searchCode): string
+    {
+        return hash('sha256', $config->getFieldSet()->getSetName().'~'.$searchCode);
+    }
+}

--- a/src/Processor/NullCache.php
+++ b/src/Processor/NullCache.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform\Processor;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class NullCache implements CacheInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key, $default = null)
+    {
+        return $default;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        foreach ($keys as $key) {
+            yield $key => $default;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($key)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($key)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteMultiple($keys)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        return false;
+    }
+}

--- a/src/Serializer/InvalidSearchConditionNormalizer.php
+++ b/src/Serializer/InvalidSearchConditionNormalizer.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 final class InvalidSearchConditionNormalizer implements NormalizerInterface
 {
-    const FORMAT = 'jsonld';
+    const FORMAT = 'jsonproblem';
 
     /**
      * @var UrlGeneratorInterface

--- a/tests/Fixtures/BookFieldSet.php
+++ b/tests/Fixtures/BookFieldSet.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform\Tests\Fixtures;
+
+use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
+use Rollerworks\Component\Search\Extension\Core\Type\TextType;
+use Rollerworks\Component\Search\FieldSetBuilder;
+use Rollerworks\Component\Search\FieldSetConfigurator;
+
+final class BookFieldSet implements FieldSetConfigurator
+{
+    public function buildFieldSet(FieldSetBuilder $builder)
+    {
+        $builder->add('id', IntegerType::class);
+        $builder->add('title', TextType::class);
+    }
+}

--- a/tests/Processor/ApiSearchProcessorTest.php
+++ b/tests/Processor/ApiSearchProcessorTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform\Tests\Processor;
+
+use Psr\SimpleCache\CacheInterface;
+use Rollerworks\Component\Search\ApiPlatform\Processor\ApiSearchProcessor;
+use Rollerworks\Component\Search\ApiPlatform\Tests\Fixtures\BookFieldSet;
+use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\Loader\ConditionExporterLoader;
+use Rollerworks\Component\Search\Loader\InputProcessorLoader;
+use Rollerworks\Component\Search\Processor\ProcessorConfig;
+use Rollerworks\Component\Search\Processor\SearchPayload;
+use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
+use Rollerworks\Component\Search\Value\ValuesBag;
+use Rollerworks\Component\Search\Value\ValuesGroup;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ApiSearchProcessorTest extends SearchIntegrationTestCase
+{
+    /**
+     * @var FieldSet
+     */
+    private $fieldSet;
+
+    /**
+     * @var SearchCondition
+     */
+    private $condition;
+
+    /**
+     * @var SearchCondition
+     */
+    private $conditionOptimized;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|CacheInterface
+     */
+    private $cache;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->cache = $this->createMock(CacheInterface::class);
+        $this->fieldSet = $this->getFactory()->createFieldSet(BookFieldSet::class);
+        $this->condition = new SearchCondition(
+            $this->fieldSet,
+            (new ValuesGroup())->addField('title', (new ValuesBag())->addSimpleValue('Symfony'))
+        );
+
+        $this->conditionOptimized = new SearchCondition(
+            $this->fieldSet,
+            (new ValuesGroup())->addField(
+                'title',
+                (new ValuesBag())->addSimpleValue('Symfony')->addSimpleValue('Symfony')->removeSimpleValue(0)
+            )
+        );
+    }
+
+    private function createProcessor()
+    {
+        $processor = new ApiSearchProcessor(
+            $this->getFactory(),
+            InputProcessorLoader::create(),
+            ConditionExporterLoader::create(),
+            $this->cache
+        );
+
+        return $processor;
+    }
+
+    public function testProcessingEmptyRequestIsValid()
+    {
+        $config = new ProcessorConfig($this->fieldSet);
+        $request = Request::create('/books', 'GET');
+
+        $payload = $this->createProcessor()->processRequest($request, $config);
+
+        self::assertFalse($payload->isChanged());
+        self::assertTrue($payload->isValid());
+        self::assertEmpty($payload->messages);
+        self::assertNull($payload->searchCondition);
+        self::assertNull($payload->exportedFormat);
+        self::assertEmpty($payload->searchCode);
+    }
+
+    public function testProcessSearchCodeFromQuery()
+    {
+        $config = new ProcessorConfig($this->fieldSet);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['title' => ['simple-values' => ['Symfony']]]]]);
+
+        $payload = $this->createProcessor()->processRequest($request, $config);
+
+        self::assertFalse($payload->isChanged());
+        self::assertTrue($payload->isValid());
+        self::assertEmpty($payload->messages);
+        self::assertEquals($this->condition, $payload->searchCondition);
+        self::assertEquals('array', $payload->exportedFormat);
+        self::assertEquals(['fields' => ['title' => ['simple-values' => ['Symfony']]]], $payload->exportedCondition);
+        self::assertEquals('fields%5Btitle%5D%5Bsimple-values%5D%5B0%5D=Symfony', $payload->searchCode);
+    }
+
+    public function testProcessSearchCodeWithChanges()
+    {
+        $config = new ProcessorConfig($this->fieldSet);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['title' => ['simple-values' => ['Symfony', 'Symfony']]]]]);
+
+        $payload = $this->createProcessor()->processRequest($request, $config);
+
+        self::assertTrue($payload->isChanged());
+        self::assertTrue($payload->isValid());
+        self::assertEmpty($payload->messages);
+        self::assertEquals($this->conditionOptimized, $payload->searchCondition);
+        self::assertEquals('array', $payload->exportedFormat);
+        self::assertEquals(['fields' => ['title' => ['simple-values' => ['Symfony']]]], $payload->exportedCondition);
+        self::assertEquals('fields%5Btitle%5D%5Bsimple-values%5D%5B0%5D=Symfony', $payload->searchCode);
+    }
+
+    public function testSearchCodeOnlyAcceptsArray()
+    {
+        $config = new ProcessorConfig($this->fieldSet);
+        $request = Request::create('/books', 'GET', ['search' => '']);
+
+        $payload = $this->createProcessor()->processRequest($request, $config);
+
+        self::assertTrue($payload->isValid());
+        self::assertFalse($payload->isChanged());
+        self::assertNull($payload->searchCondition);
+        self::assertEquals('', $payload->exportedCondition);
+        self::assertEquals('', $payload->searchCode);
+    }
+
+    public function testSearchCodeWithSyntaxErrorIsInvalid()
+    {
+        $config = new ProcessorConfig($this->fieldSet);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['id' => ['simple-values' => ['He']]]]]);
+
+        // Unlike other processors this will throw the exception globally so the ExceptionListener can
+        // catch it. And no rethrow is required.
+        $this->expectException(InvalidSearchConditionException::class);
+
+        $this->createProcessor()->processRequest($request, $config);
+    }
+
+    public function testProcessSearchCodeFromQueryWithNoCache()
+    {
+        $config = new ProcessorConfig($this->fieldSet);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['title' => ['simple-values' => ['Symfony']]]]]);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('get')
+            ->with('8eb42c0970710702a40e010b470f6586b8301117231dd4fdd1a51576c293f89f')
+            ->willReturn(null);
+
+        $storedPayload = new SearchPayload(false);
+        $storedPayload->searchCondition = $this->getFactory()->getSerializer()->serialize($this->condition);
+        $storedPayload->searchCode = 'fields%5Btitle%5D%5Bsimple-values%5D%5B0%5D=Symfony';
+        $storedPayload->exportedCondition = ['fields' => ['title' => ['simple-values' => ['Symfony']]]];
+        $storedPayload->exportedFormat = 'array';
+        $storedPayload->messages = [];
+
+        $this->cache
+            ->expects(self::once())
+            ->method('set')
+            ->with('8eb42c0970710702a40e010b470f6586b8301117231dd4fdd1a51576c293f89f', $storedPayload);
+
+        $payload = $this->createProcessor()->processRequest($request, $config);
+
+        self::assertFalse($payload->isChanged());
+        self::assertTrue($payload->isValid());
+        self::assertEmpty($payload->messages);
+        self::assertEquals($this->condition, $payload->searchCondition);
+        self::assertEquals('array', $payload->exportedFormat);
+        self::assertEquals(['fields' => ['title' => ['simple-values' => ['Symfony']]]], $payload->exportedCondition);
+        self::assertEquals('fields%5Btitle%5D%5Bsimple-values%5D%5B0%5D=Symfony', $payload->searchCode);
+    }
+
+    public function testProcessSearchCodeFromQueryStoresOptimized()
+    {
+        $config = new ProcessorConfig($this->fieldSet);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['title' => ['simple-values' => ['Symfony', 'Symfony']]]]]);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('get')
+            ->with('dfb6a7d17a8380b5aea06bb965d7de340cd3ad25df93d7469cf84cb7ed0fb37c')
+            ->willReturn(null);
+
+        $storedPayload = new SearchPayload(false);
+        $storedPayload->searchCondition = $this->getFactory()->getSerializer()->serialize($this->conditionOptimized);
+        $storedPayload->searchCode = 'fields%5Btitle%5D%5Bsimple-values%5D%5B0%5D=Symfony';
+        $storedPayload->exportedCondition = ['fields' => ['title' => ['simple-values' => [0 => 'Symfony']]]];
+        $storedPayload->exportedFormat = 'array';
+        $storedPayload->messages = [];
+
+        $this->cache
+            ->expects(self::once())
+            ->method('set')
+            ->with('8eb42c0970710702a40e010b470f6586b8301117231dd4fdd1a51576c293f89f', $storedPayload);
+
+        $payload = $this->createProcessor()->processRequest($request, $config);
+
+        self::assertTrue($payload->isChanged());
+        self::assertTrue($payload->isValid());
+        self::assertEmpty($payload->messages);
+        self::assertEquals($this->conditionOptimized, $payload->searchCondition);
+        self::assertEquals('array', $payload->exportedFormat);
+        self::assertEquals(['fields' => ['title' => ['simple-values' => [0 => 'Symfony']]]], $payload->exportedCondition);
+        self::assertEquals('fields%5Btitle%5D%5Bsimple-values%5D%5B0%5D=Symfony', $payload->searchCode);
+    }
+
+    public function testProcessSearchCodeFromQueryWithExistingCache()
+    {
+        // This condition would have given an transformer error,
+        // so getting one means the transformer was never executed.
+        $config = new ProcessorConfig($this->fieldSet);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['id' => ['simple-values' => ['He']]]]]);
+
+        $storedPayload = new SearchPayload(false);
+        $storedPayload->searchCondition = $this->getFactory()->getSerializer()->serialize($this->condition);
+        $storedPayload->searchCode = 'fields[id][simple-values][0]=He';
+        $storedPayload->exportedCondition = ['fields' => ['id' => ['simple-values' => ['He']]]];
+        $storedPayload->exportedFormat = 'array';
+        $storedPayload->messages = [];
+
+        $this->cache
+            ->expects(self::once())
+            ->method('get')
+            ->with('46c9f402cb1b5d2208ed62e0a9242cd2f43891a48949eb4c477ad2a053b81355')
+            ->willReturn($storedPayload);
+
+        $payload = $this->createProcessor()->processRequest($request, $config);
+
+        self::assertFalse($payload->isChanged());
+        self::assertTrue($payload->isValid());
+        self::assertEmpty($payload->messages);
+        self::assertEquals($this->condition, $payload->searchCondition);
+        self::assertEquals('array', $payload->exportedFormat);
+        self::assertEquals(['fields' => ['id' => ['simple-values' => ['He']]]], $payload->exportedCondition);
+        self::assertEquals('fields[id][simple-values][0]=He', $payload->searchCode);
+
+        $this->cache
+            ->expects(self::never())
+            ->method('set');
+    }
+
+    public function testProcessSearchCodeWithInvalidCacheIsDeletedAndReProcessed()
+    {
+        $config = new ProcessorConfig($this->fieldSet);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['title' => ['simple-values' => ['Symfony']]]]]);
+
+        $storedPayload = new SearchPayload(false);
+        $storedPayload->searchCondition = [$this->condition->getFieldSet()->getSetName(), 'invalid-I-am-I-am'];
+        $storedPayload->searchCode = 'fields[id][simple-values][0]=He';
+        $storedPayload->exportedCondition = ['fields' => ['id' => ['simple-values' => ['He']]]];
+        $storedPayload->exportedFormat = 'array';
+        $storedPayload->messages = [];
+
+        $this->cache
+            ->expects(self::once())
+            ->method('get')
+            ->with('8eb42c0970710702a40e010b470f6586b8301117231dd4fdd1a51576c293f89f')
+            ->willReturn($storedPayload);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('8eb42c0970710702a40e010b470f6586b8301117231dd4fdd1a51576c293f89f');
+
+        $payload = new SearchPayload();
+        $payload->searchCondition = $this->condition;
+        $payload->searchCode = 'fields%5Btitle%5D%5Bsimple-values%5D%5B0%5D=Symfony';
+        $payload->exportedCondition = ['fields' => ['title' => ['simple-values' => ['Symfony']]]];
+        $payload->exportedFormat = 'array';
+        $payload->messages = [];
+
+        $newPayload = clone $payload;
+        $newPayload->searchCondition = $this->getFactory()->getSerializer()->serialize($this->condition);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('set')
+            ->with('8eb42c0970710702a40e010b470f6586b8301117231dd4fdd1a51576c293f89f', $newPayload);
+
+        $payload = $this->createProcessor()->processRequest($request, $config);
+
+        self::assertFalse($payload->isChanged());
+        self::assertTrue($payload->isValid());
+        self::assertEmpty($payload->messages);
+        self::assertEquals($this->condition, $payload->searchCondition);
+        self::assertEquals('array', $payload->exportedFormat);
+        self::assertEquals(['fields' => ['title' => ['simple-values' => ['Symfony']]]], $payload->exportedCondition);
+        self::assertEquals('fields%5Btitle%5D%5Bsimple-values%5D%5B0%5D=Symfony', $payload->searchCode);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | Pending

The ApiSearchProcessor, unlike other other processors works with HttpFoundation, only accepts one condition per request, works with GET only (no post) and uses a URI formatted query-string (more readable and easier to implement).

Caching is already build-in as this processor does less then others, so complexity is still kept minimum. And fixed a number of small bugs and issues.