### PR TITLE
Redesign the Metadata structure for better DX

### DIFF
--- a/Metadata-reference.md
+++ b/Metadata-reference.md
@@ -2,32 +2,22 @@ Class:
 
 ```php
  "rollerworks_search" = {
-    "fieldset" = "..." # optional, fields can also be configured using the ResourceMetadata properties (requires a custom FieldSetRegistry)
-    "accepted_fieldsets" = [] # limiting, otherwise all are accepted. Ignored when the FieldSet is kept within the ResourceMetadata
-    "processor" = { } # Options for the processor
-    "doctrine_orm" = {
-        "FieldSetName | *" = {
-            "relations" = {
-                "alias" = { "type (left | right | inner)" "join", "conditionType", "condition", "indexBy" }
-            }
-            "mappings" = {
-                "mapping-name" = { "property", "alias", "db_type" }
-            }
+    "contexts" = {
+        "_default" {
+            # Set defaults, merged with more specific configuration (and _any)
+        },
+        "ContextName | _any" = { # ContextName is provided using event listeners (request#attributes[_search_context])
+            "fieldset" = "...", # Required
+            "processor" = { }, # Options for the processor
+            "doctrine_orm" = {
+                "relations" = {
+                    "alias" = { "type (left | right | inner)", "entity" "join", "conditionType", "condition", "indexBy" }
+                },
+                "mappings" = {
+                    "mapping-name" = { "property", "alias", "db_type" }
+                },
+            },
         }
-    },
-    # Fields, merged with property fields. Mainly to be used for children
-    "fields" = {}
+    }
 }
 ```
-
-Property (FieldSet building):
-
-```php
-"rollerworks_search" = {
-    "field" = { "name" = { "type", "options" } } # Optional, cannot be merged with existing FieldSet's
-}
-```
-
-**Note:** FieldSet building is limited to the current resource (no children)
-and only allows one configuration. Backend/frontend configurations require
-separate FieldSet configurators instead.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "rollerworks/search-processor": "^0.2.0",
         "rollerworks/search": "^2.0,>=2.0.0-ALPHA2",
         "rollerworks/uri-encoder": "^1.1.0",
-        "api-platform/core": "^2.0.3"
+        "api-platform/core": "^2.0.3",
+        "symfony/http-foundation": "^3.2.6"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.2.6",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,8 @@
             <exclude>
                 <directory>./vendor/</directory>
                 <directory>./tests/</directory>
+                <file>src/Doctrine/Orm/CollectionDataProvider.php</file>
+                <file>src/Doctrine/Orm/QueryBuilder.php</file>
             </exclude>
         </whitelist>
     </filter>

--- a/src/EventListener/SearchConditionListener.php
+++ b/src/EventListener/SearchConditionListener.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\ApiPlatform\EventListener;
 
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
+use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface as ResourceMetadataFactory;
-use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
 use Rollerworks\Component\Search\Processor\ProcessorConfig;
 use Rollerworks\Component\Search\Processor\SearchProcessor;
 use Rollerworks\Component\Search\SearchFactory;
@@ -23,6 +23,17 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
+/**
+ * SearchConditionListener handles search conditions provided with the Request query.
+ *
+ * The condition is expected to be provided as an ArrayInput format at `search`.
+ * After this the Request attribute `_api_search_condition` is set with SearchCondition object.
+ *
+ * When there is an error the processor is expected to throw an exception.
+ * Exceptions are not handled by this listener!
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
 final class SearchConditionListener
 {
     private $searchFactory;
@@ -30,6 +41,14 @@ final class SearchConditionListener
     private $urlGenerator;
     private $resourceMetadataFactory;
 
+    /**
+     * Constructor.
+     *
+     * @param SearchFactory           $searchFactory
+     * @param SearchProcessor         $searchProcessor         ApiSearchProcessor instance
+     * @param UrlGeneratorInterface   $urlGenerator
+     * @param ResourceMetadataFactory $resourceMetadataFactory
+     */
     public function __construct(SearchFactory $searchFactory, SearchProcessor $searchProcessor, UrlGeneratorInterface $urlGenerator, ResourceMetadataFactory $resourceMetadataFactory)
     {
         $this->searchFactory = $searchFactory;
@@ -38,6 +57,14 @@ final class SearchConditionListener
         $this->resourceMetadataFactory = $resourceMetadataFactory;
     }
 
+    /**
+     * Listener callback.
+     *
+     * This listener is expected to be run after the Api EntryPoint but before ReadListener
+     * on the kernel.request event.
+     *
+     * @param GetResponseEvent $event
+     */
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
@@ -46,59 +73,109 @@ final class SearchConditionListener
             return;
         }
 
-        if (null === $fieldSet = $this->resolveFieldSetName($request)) {
+        $resourceClass = $request->attributes->get('_api_resource_class');
+        $searchConfig = $this->resourceMetadataFactory->create($resourceClass)->getAttribute('rollerworks_search');
+
+        if (empty($searchConfig)) {
             return;
         }
 
-        // FIXME Make this configurable: array to method calls
-        // XXX Try to guess format based on Accept
+        $searchConfig = $this->resolveSearchConfiguration($searchConfig, $resourceClass, $request);
 
-        $config = new ProcessorConfig($this->searchFactory->createFieldSet($fieldSet), 'json');
+        $config = new ProcessorConfig($this->searchFactory->createFieldSet($searchConfig['fieldset']), 'array');
+        $this->configureProcessor($config, $searchConfig, $resourceClass);
         $payload = $this->searchProcessor->processRequest($request, $config);
-
-        if (!$payload->isValid()) {
-            throw new InvalidSearchConditionException($payload->messages);
-        }
 
         if ($payload->isValid() && $payload->isChanged()) {
             $routeArguments = array_merge(
                 $request->query->all(),
-                ['search' => $payload->exportedCondition] // Use array instead or string ()
+                $this->resolveRouteArguments($request), // Execute after query to prevent overwriting.
+                ['search' => $payload->exportedCondition] // Use array instead or string.
             );
-
-            if (null !== $format = $request->attributes->get('_format')) {
-                $routeArguments['_format'] = $format;
-            }
 
             $event->setResponse(new RedirectResponse(
                 $this->urlGenerator->generate($request->attributes->get('_route'), $routeArguments)
             ));
+
+            return;
         }
 
         $request->attributes->set('_api_search_condition', $payload->searchCondition);
     }
 
-    private function resolveFieldSetName(Request $request): ?string
+    private function resolveSearchConfiguration(array $searchConfig, string $resourceClass, Request $request)
     {
-        if (null !== $fieldSet = $request->attributes->get('_api_search_fieldset')) {
-            return $fieldSet;
+        if (empty($searchConfig['contexts'])) {
+            throw new RuntimeException(
+                sprintf(
+                    'Resource "%s" is missing a contexts array. Add a "contexts" array with at least one entry.',
+                    $resourceClass.'#attributes[rollerworks_search]'
+                )
+            );
         }
 
-        $resourceClass = $request->attributes->get('_api_resource_class');
-        $searchConfig = $this->resourceMetadataFactory->create($resourceClass)->getAttribute('rollerworks_search');
+        $context = $request->attributes->get('_api_search_context', '_any');
 
-        if (empty($searchConfig)) {
-            return null;
+        if (!isset($searchConfig['contexts'][$context])) {
+            throw new RuntimeException(
+                sprintf(
+                    'Search context "%s" is not supported for Resource "%s", supported: "%s".',
+                    $context,
+                    $resourceClass.'#attributes[rollerworks_search][contexts]',
+                    implode('", "', array_keys($searchConfig['contexts']))
+                )
+            );
         }
 
-        if (!empty($searchConfig['fieldset'])) {
-            return $searchConfig['fieldset'];
+        if (empty($searchConfig['contexts'][$context]) || empty($searchConfig['contexts'][$context]['fieldset'])) {
+            throw new RuntimeException(
+                sprintf(
+                    'Search context "%s" is incorrectly configured for Resource "%s", missing a "fieldset" reference.',
+                    $context,
+                    $resourceClass.'#attributes[rollerworks_search]'
+                )
+            );
         }
 
-        if (!empty($searchConfig['fields'])) {
-            return $resourceClass;
+        $request->attributes->set('_api_search_context', $context);
+        $request->attributes->set('_api_search_config', $searchConfig['contexts'][$context]);
+
+        return $searchConfig['contexts'][$context];
+    }
+
+    private function configureProcessor(ProcessorConfig $config, array $options, string $resourceClass)
+    {
+        if (empty($options['processor'])) {
+            return;
         }
 
-        return null;
+        foreach ($options['processor'] as $option => $value) {
+            $method = 'set'.ucfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $option))));
+
+            if (!method_exists($config, $method)) {
+                throw new RuntimeException(sprintf('Processor option "%s" is not supported for Resource "%s".', $option, $resourceClass));
+            }
+
+            if (ctype_digit($value)) {
+                $value = (int) $value;
+            }
+
+            $config->{$method}($value);
+        }
+    }
+
+    private function resolveRouteArguments(Request $request): array
+    {
+        $values = [];
+
+        foreach ($request->attributes->get('_route_params', []) as $name => $value) {
+            if (('_locale' !== $name && '_format' !== $name && '_' === $name[0]) || is_array($value)) {
+                continue;
+            }
+
+            $values[$name] = $value;
+        }
+
+        return $values;
     }
 }

--- a/src/Metadata/DefaultConfigurationMetadataFactory.php
+++ b/src/Metadata/DefaultConfigurationMetadataFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform\Metadata;
+
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+
+/**
+ * The DefaultConfigurationMetadataFactory merges the `_default` configuration
+ * of the `rollerworks_search` resource attribute to all configs.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class DefaultConfigurationMetadataFactory implements ResourceMetadataFactoryInterface
+{
+    private $decorated;
+
+    public function __construct(ResourceMetadataFactoryInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * Creates a resource metadata.
+     *
+     * @param string $resourceClass
+     *
+     * @return ResourceMetadata
+     */
+    public function create(string $resourceClass): ResourceMetadata
+    {
+        $resourceMetadata = $this->decorated->create($resourceClass);
+        $searchConfig = $resourceMetadata->getAttribute('rollerworks_search');
+
+        if (empty($searchConfig) || empty($searchConfig['contexts']['_default'])) {
+            return $resourceMetadata;
+        }
+
+        $configurations = $searchConfig['contexts'];
+        unset($configurations['_default']);
+
+        foreach ($configurations as $name => $configuration) {
+            $configurations[$name] = array_replace_recursive($searchConfig['contexts']['_default'], $configuration);
+        }
+
+        $attributes = $resourceMetadata->getAttributes();
+        $attributes['rollerworks_search']['contexts'] = $configurations;
+
+        return $resourceMetadata->withAttributes($attributes);
+    }
+}

--- a/tests/EventListener/SearchConditionListenerTest.php
+++ b/tests/EventListener/SearchConditionListenerTest.php
@@ -1,0 +1,519 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform\Tests\EventListener;
+
+use ApiPlatform\Core\Api\UrlGeneratorInterface;
+use ApiPlatform\Core\Exception\RuntimeException;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use Prophecy\Argument;
+use Rollerworks\Component\Search\ApiPlatform\EventListener\SearchConditionListener;
+use Rollerworks\Component\Search\ApiPlatform\Tests\Fixtures\BookFieldSet;
+use Rollerworks\Component\Search\ApiPlatform\Tests\Fixtures\Dummy;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\Processor\ProcessorConfig;
+use Rollerworks\Component\Search\Processor\SearchPayload;
+use Rollerworks\Component\Search\Processor\SearchProcessor;
+use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
+use Rollerworks\Component\Search\Value\ValuesGroup;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class SearchConditionListenerTest extends SearchIntegrationTestCase
+{
+    /** @test */
+    public function it_sets_search_condition_and_config()
+    {
+        $dummyMetadata = new ResourceMetadata(
+            'dummy',
+            'dummy',
+            '#dummy',
+            [],
+            [],
+            [
+                'rollerworks_search' => [
+                    'contexts' => [
+                        '_any' => [
+                            'fieldset' => BookFieldSet::class,
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $resourceMetadataFactory = $this->createResourceMetadata($dummyMetadata);
+
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class]);
+
+        $searchPayload = new SearchPayload();
+        $searchPayload->searchCondition = $condition = $this->createCondition();
+        $searchPayload->exportedFormat = 'array';
+        $searchPayload->exportedCondition = ['fields' => ['id' => ['single-values' => [1, 2]]]];
+
+        $processorProphecy = $this->prophesize(SearchProcessor::class);
+        $processorProphecy->processRequest($request, Argument::any())->willReturn($searchPayload);
+        $searchProcessor = $processorProphecy->reveal();
+
+        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
+        $urlGenerator = $urlGeneratorProphecy->reveal();
+
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        self::assertNull($event->getResponse());
+        self::assertEquals(
+            [
+                '_api_resource_class' => Dummy::class,
+                '_api_search_config' => ['fieldset' => BookFieldSet::class],
+                '_api_search_context' => '_any',
+                '_api_search_condition' => $condition,
+            ],
+            $request->attributes->all()
+        );
+    }
+
+    /** @test */
+    public function it_sets_search_condition_and_config_for_context()
+    {
+        $dummyMetadata = new ResourceMetadata(
+            'dummy',
+            'dummy',
+            '#dummy',
+            [],
+            [],
+            [
+                'rollerworks_search' => [
+                    'contexts' => [
+                        '_any' => [
+                            'fieldset' => 'book',
+                        ],
+                        'frontend' => [
+                            'fieldset' => BookFieldSet::class,
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $resourceMetadataFactory = $this->createResourceMetadata($dummyMetadata);
+
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class, '_api_search_context' => 'frontend']);
+
+        $searchPayload = new SearchPayload();
+        $searchPayload->searchCondition = $condition = $this->createCondition();
+        $searchPayload->exportedFormat = 'array';
+        $searchPayload->exportedCondition = ['fields' => ['id' => ['single-values' => [1, 2]]]];
+
+        $processorProphecy = $this->prophesize(SearchProcessor::class);
+        $processorProphecy->processRequest($request, Argument::any())->willReturn($searchPayload);
+        $searchProcessor = $processorProphecy->reveal();
+
+        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
+        $urlGenerator = $urlGeneratorProphecy->reveal();
+
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        self::assertNull($event->getResponse());
+        self::assertEquals(
+            [
+                '_api_resource_class' => Dummy::class,
+                '_api_search_config' => ['fieldset' => BookFieldSet::class],
+                '_api_search_context' => 'frontend',
+                '_api_search_condition' => $condition,
+            ],
+            $request->attributes->all()
+        );
+    }
+
+    /** @test */
+    public function it_sets_a_redirect_when_search_condition_has_changed()
+    {
+        $dummyMetadata = new ResourceMetadata(
+            'dummy',
+            'dummy',
+            '#dummy',
+            [],
+            [],
+            [
+                'rollerworks_search' => [
+                    'contexts' => [
+                        '_any' => [
+                            'fieldset' => BookFieldSet::class,
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $resourceMetadataFactory = $this->createResourceMetadata($dummyMetadata);
+
+        $request = new Request(
+            ['search' => ['fields' => ['id' => ['single-values' => [1, 1]]]]],
+            [],
+            ['_api_resource_class' => Dummy::class, '_route' => 'api_books_collection']
+        );
+
+        $searchPayload = new SearchPayload(true);
+        $searchPayload->searchCondition = $condition = $this->createCondition();
+        $searchPayload->exportedFormat = 'array';
+        $searchPayload->exportedCondition = ['fields' => ['id' => ['single-values' => [1]]]];
+
+        $processorProphecy = $this->prophesize(SearchProcessor::class);
+        $processorProphecy->processRequest($request, Argument::any())->willReturn($searchPayload);
+        $searchProcessor = $processorProphecy->reveal();
+
+        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGeneratorProphecy->generate(
+            'api_books_collection',
+            ['search' => ['fields' => ['id' => ['single-values' => [1]]]]],
+            Argument::any()
+        )->willReturn('/books?search[fields][id][0]=1');
+
+        $urlGenerator = $urlGeneratorProphecy->reveal();
+
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        self::assertEquals(new RedirectResponse('/books?search[fields][id][0]=1'), $event->getResponse());
+        self::assertEquals(
+            [
+                '_api_resource_class' => Dummy::class,
+                '_api_search_config' => ['fieldset' => BookFieldSet::class],
+                '_api_search_context' => '_any',
+                '_route' => 'api_books_collection',
+            ],
+            $request->attributes->all()
+        );
+    }
+
+    /** @test */
+    public function it_sets_a_redirect_with_format_when_search_condition_has_changed()
+    {
+        $dummyMetadata = new ResourceMetadata(
+            'dummy',
+            'dummy',
+            '#dummy',
+            [],
+            [],
+            [
+                'rollerworks_search' => [
+                    'contexts' => [
+                        '_any' => [
+                            'fieldset' => BookFieldSet::class,
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $resourceMetadataFactory = $this->createResourceMetadata($dummyMetadata);
+
+        $request = new Request(
+            ['search' => ['fields' => ['id' => ['single-values' => [1, 1]]]]],
+            [],
+            [
+                '_api_resource_class' => Dummy::class,
+                '_format' => 'json',
+                '_route' => 'api_books_collection',
+                '_route_params' => [
+                    '_api_resource_class' => Dummy::class,
+                    '_format' => 'json',
+                ],
+            ]
+        );
+
+        $searchPayload = new SearchPayload(true);
+        $searchPayload->searchCondition = $condition = $this->createCondition();
+        $searchPayload->exportedFormat = 'array';
+        $searchPayload->exportedCondition = ['fields' => ['id' => ['single-values' => [1]]]];
+
+        $processorProphecy = $this->prophesize(SearchProcessor::class);
+        $processorProphecy->processRequest($request, Argument::any())->willReturn($searchPayload);
+        $searchProcessor = $processorProphecy->reveal();
+
+        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGeneratorProphecy->generate(
+            'api_books_collection',
+            ['_format' => 'json', 'search' => ['fields' => ['id' => ['single-values' => [1]]]]],
+            Argument::any()
+        )->willReturn('/books.json?search[fields][id][0]=1');
+
+        $urlGenerator = $urlGeneratorProphecy->reveal();
+
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        self::assertEquals(new RedirectResponse('/books.json?search[fields][id][0]=1'), $event->getResponse());
+        self::assertEquals(
+            [
+                '_api_resource_class' => Dummy::class,
+                '_api_search_config' => ['fieldset' => BookFieldSet::class],
+                '_api_search_context' => '_any',
+                '_format' => 'json',
+                '_route' => 'api_books_collection',
+                '_route_params' => [
+                    '_api_resource_class' => Dummy::class,
+                    '_format' => 'json',
+                ],
+            ],
+            $request->attributes->all()
+        );
+    }
+
+    /** @test */
+    public function it_does_nothing_when_no_metadata_is_set()
+    {
+        $dummyMetadata = new ResourceMetadata('dummy', 'dummy', '#dummy');
+
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $resourceMetadataFactory = $this->createResourceMetadata($dummyMetadata);
+
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class]);
+
+        $processorProphecy = $this->prophesize(SearchProcessor::class);
+        $processorProphecy->processRequest(Argument::any(), Argument::any())->shouldNotBeCalled();
+        $searchProcessor = $processorProphecy->reveal();
+
+        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
+        $urlGenerator = $urlGeneratorProphecy->reveal();
+
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        self::assertNull($event->getResponse());
+        self::assertEquals(['_api_resource_class' => Dummy::class], $request->attributes->all());
+    }
+
+    /** @test */
+    public function it_does_nothing_not_cacheable_requests()
+    {
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create(Argument::any())->shouldNotBeCalled();
+        $resourceMetadataFactory = $resourceMetadataFactoryProphecy->reveal();
+
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class]);
+        $request->setMethod('POST');
+
+        $processorProphecy = $this->prophesize(SearchProcessor::class);
+        $processorProphecy->processRequest(Argument::any(), Argument::any())->shouldNotBeCalled();
+        $searchProcessor = $processorProphecy->reveal();
+
+        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
+        $urlGenerator = $urlGeneratorProphecy->reveal();
+
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        self::assertNull($event->getResponse());
+        self::assertEquals(['_api_resource_class' => Dummy::class], $request->attributes->all());
+    }
+
+    /** @test */
+    public function it_maps_configuration_processor_configuration()
+    {
+        $dummyMetadata = new ResourceMetadata(
+            'dummy',
+            'dummy',
+            '#dummy',
+            [],
+            [],
+            [
+                'rollerworks_search' => [
+                    'contexts' => [
+                        '_any' => [
+                            'fieldset' => BookFieldSet::class,
+                            'processor' => [
+                                'cache_ttl' => '30',
+                                'ExportFormat' => 'json',
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $resourceMetadataFactory = $this->createResourceMetadata($dummyMetadata);
+
+        $request = new Request([], [], ['_api_resource_class' => Dummy::class]);
+
+        $searchPayload = new SearchPayload();
+        $searchPayload->searchCondition = $condition = $this->createCondition();
+        $searchPayload->exportedFormat = 'array';
+        $searchPayload->exportedCondition = ['fields' => ['id' => ['single-values' => [1, 2]]]];
+
+        $fieldSet = $this->getFactory()->createFieldSet(BookFieldSet::class);
+        $processorConfig = new ProcessorConfig($fieldSet, 'array');
+        $processorConfig->setCacheTTL(30);
+        $processorConfig->setExportFormat('json');
+
+        $processorProphecy = $this->prophesize(SearchProcessor::class);
+        $processorProphecy->processRequest($request, $processorConfig)->willReturn($searchPayload);
+        $searchProcessor = $processorProphecy->reveal();
+
+        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
+        $urlGenerator = $urlGeneratorProphecy->reveal();
+
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        self::assertNull($event->getResponse());
+        self::assertEquals(
+            [
+                '_api_resource_class' => Dummy::class,
+                '_api_search_config' => [
+                    'fieldset' => BookFieldSet::class,
+                    'processor' => ['cache_ttl' => '30', 'ExportFormat' => 'json'],
+                ],
+                '_api_search_context' => '_any',
+                '_api_search_condition' => $condition,
+            ],
+            $request->attributes->all()
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider provideInvalidConfigurations
+     */
+    public function it_errors_when_context_configuration_is_invalid(string $message, array $config)
+    {
+        $dummyMetadata = new ResourceMetadata(
+            'dummy',
+            'dummy',
+            '#dummy',
+            [],
+            [],
+            $config
+        );
+
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $resourceMetadataFactory = $this->createResourceMetadata($dummyMetadata);
+
+        $request = new Request(
+            ['search' => ['fields' => ['id' => ['single-values' => [1, 1]]]]],
+            [],
+            ['_api_resource_class' => Dummy::class]
+        );
+
+        $processorProphecy = $this->prophesize(SearchProcessor::class);
+        $processorProphecy->processRequest($request, Argument::any())->shouldNotBeCalled();
+        $searchProcessor = $processorProphecy->reveal();
+
+        $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
+        $urlGenerator = $urlGeneratorProphecy->reveal();
+
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($message);
+
+        $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
+    }
+
+    public function provideInvalidConfigurations(): array
+    {
+        $resourceClass = Dummy::class;
+
+        return [
+            'context with missing fieldset' => [
+                'Search context "_any" is incorrectly configured for Resource "'.$resourceClass.'#attributes[rollerworks_search]", missing a "fieldset" reference.',
+                [
+                    'rollerworks_search' => [
+                        'contexts' => [
+                            '_any' => [
+                                'processor' => ['cache_ttl' => '30'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'unsupported processor option' => [
+                'Processor option "foo" is not supported for Resource "'.$resourceClass.'".',
+                [
+                    'rollerworks_search' => [
+                        'contexts' => [
+                            '_any' => [
+                                'fieldset' => BookFieldSet::class,
+                                'processor' => ['cache_ttl' => '30', 'foo' => 'bar'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'unregistered context' => [
+                'Search context "_any" is not supported for Resource "'.$resourceClass.'#attributes[rollerworks_search][contexts]", supported: "foo", "bar".',
+                [
+                    'rollerworks_search' => [
+                        'contexts' => [
+                            'foo' => [
+                                'fieldset' => BookFieldSet::class,
+                                'processor' => ['cache_ttl' => '30', 'foo' => 'bar'],
+                            ],
+                            'bar' => [
+                                'fieldset' => BookFieldSet::class,
+                                'processor' => ['cache_ttl' => '30', 'foo' => 'bar'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'contexts' => [
+                'Resource "'.$resourceClass.'#attributes[rollerworks_search]" is missing a contexts array. Add a "contexts" array with at least one entry.',
+                [
+                    'rollerworks_search' => [
+                        '_contexts' => [
+                            'foo' => [
+                                'fieldset' => BookFieldSet::class,
+                                'processor' => ['cache_ttl' => '30', 'foo' => 'bar'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function createResourceMetadata(ResourceMetadata $metadata = null, string $resourceClass = Dummy::class): ResourceMetadataFactoryInterface
+    {
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create($resourceClass)->shouldBeCalled()->willReturn($metadata);
+
+        return $resourceMetadataFactoryProphecy->reveal();
+    }
+
+    private function createCondition(?string $setName = BookFieldSet::class): SearchCondition
+    {
+        $fieldSet = $this->prophesize(FieldSet::class);
+        $fieldSet->getSetName()->willReturn($setName);
+
+        return new SearchCondition($fieldSet->reveal(), new ValuesGroup());
+    }
+}

--- a/tests/Fixtures/Dummy.php
+++ b/tests/Fixtures/Dummy.php
@@ -1,0 +1,258 @@
+<?php
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform\Tests\Fixtures;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Dummy.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @ApiResource(attributes={"filters"={"my_dummy.search", "my_dummy.order", "my_dummy.date", "my_dummy.range", "my_dummy.boolean", "my_dummy.numeric"}})
+ * @ORM\Entity
+ */
+class Dummy
+{
+    /**
+     * @var int The id
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string The dummy name
+     *
+     * @ORM\Column
+     * @Assert\NotBlank
+     * @ApiProperty(iri="http://schema.org/name")
+     */
+    private $name;
+
+    /**
+     * @var string The dummy name alias
+     *
+     * @ORM\Column(nullable=true)
+     * @ApiProperty(iri="https://schema.org/alternateName")
+     */
+    private $alias;
+
+    /**
+     * @var array foo
+     */
+    private $foo;
+
+    /**
+     * @var string A short description of the item
+     *
+     * @ORM\Column(nullable=true)
+     * @ApiProperty(iri="https://schema.org/description")
+     */
+    public $description;
+
+    /**
+     * @var string A dummy
+     *
+     * @ORM\Column(nullable=true)
+     */
+    public $dummy;
+
+    /**
+     * @var bool A dummy boolean
+     *
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    public $dummyBoolean;
+
+    /**
+     * @var \DateTime A dummy date
+     *
+     * @ORM\Column(type="datetime", nullable=true)
+     * @Assert\DateTime
+     */
+    public $dummyDate;
+
+    /**
+     * @var string A dummy float
+     *
+     * @ORM\Column(type="float", nullable=true)
+     */
+    public $dummyFloat;
+
+    /**
+     * @var string A dummy price
+     *
+     * @ORM\Column(type="decimal", precision=10, scale=2, nullable=true)
+     */
+    public $dummyPrice;
+
+    /**
+     * @var RelatedDummy A related dummy
+     *
+     * @ORM\ManyToOne(targetEntity="RelatedDummy")
+     */
+    public $relatedDummy;
+
+    /**
+     * @var ArrayCollection Several dummies
+     *
+     * @ORM\ManyToMany(targetEntity="RelatedDummy")
+     */
+    public $relatedDummies;
+
+    /**
+     * @var array serialize data
+     *
+     * @ORM\Column(type="json_array", nullable=true)
+     */
+    public $jsonData;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(nullable=true)
+     */
+    public $nameConverted;
+
+    public static function staticMethod()
+    {
+    }
+
+    public function __construct()
+    {
+        $this->relatedDummies = new ArrayCollection();
+        $this->jsonData = [];
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setAlias($alias)
+    {
+        $this->alias = $alias;
+    }
+
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function hasRole($role)
+    {
+    }
+
+    public function setFoo(array $foo = null)
+    {
+    }
+
+    public function setDummyDate(\DateTime $dummyDate = null)
+    {
+        $this->dummyDate = $dummyDate;
+    }
+
+    public function getDummyDate()
+    {
+        return $this->dummyDate;
+    }
+
+    public function setDummyPrice($dummyPrice)
+    {
+        $this->dummyPrice = $dummyPrice;
+
+        return $this;
+    }
+
+    public function getDummyPrice()
+    {
+        return $this->dummyPrice;
+    }
+
+    public function setJsonData($jsonData)
+    {
+        $this->jsonData = $jsonData;
+    }
+
+    public function getJsonData()
+    {
+        return $this->jsonData;
+    }
+
+    public function getRelatedDummy()
+    {
+        return $this->relatedDummy;
+    }
+
+    public function setRelatedDummy(RelatedDummy $relatedDummy)
+    {
+        $this->relatedDummy = $relatedDummy;
+    }
+
+    public function addRelatedDummy(RelatedDummy $relatedDummy)
+    {
+        $this->relatedDummies->add($relatedDummy);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDummyBoolean()
+    {
+        return $this->dummyBoolean;
+    }
+
+    /**
+     * @param bool $dummyBoolean
+     */
+    public function setDummyBoolean($dummyBoolean)
+    {
+        $this->dummyBoolean = $dummyBoolean;
+    }
+
+    public function setDummy($dummy = null)
+    {
+        $this->dummy = $dummy;
+    }
+
+    public function getDummy()
+    {
+        return $this->dummy;
+    }
+}

--- a/tests/Metadata/DefaultConfigurationMetadataFactoryTest.php
+++ b/tests/Metadata/DefaultConfigurationMetadataFactoryTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform\Tests\Metadata;
+
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\ApiPlatform\Metadata\DefaultConfigurationMetadataFactory;
+
+final class DefaultConfigurationMetadataFactoryTest extends TestCase
+{
+    /** @test */
+    public function it_merges_defaults_into_all_configs()
+    {
+        $resourceMetadata = new ResourceMetadata(null, 'My desc', null, null, null, [
+            'rollerworks_search' => [
+                'contexts' => [
+                    '_default' => [
+                        'processor' => [
+                            'cache_ttl' => 60,
+                            'export_format' => 'json',
+                        ],
+                        'doctrine_orm' => [
+                            'mappings' => [
+                                'dummy-id' => 'id',
+                                'dummy-name' => ['property' => 'name'],
+                            ],
+                        ],
+                    ],
+                    'foo' => [
+                        'processor' => [
+                            'export_format' => 'array',
+                        ],
+                        'doctrine_orm' => [
+                            'mappings' => [
+                                'dummy-name' => ['property' => 'userName'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $decoratedProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $decoratedProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
+        $decorated = $decoratedProphecy->reveal();
+
+        $factory = new DefaultConfigurationMetadataFactory($decorated);
+
+        $resourceMetadata = new ResourceMetadata(null, 'My desc', null, null, null, [
+            'rollerworks_search' => [
+                'contexts' => [
+                    'foo' => [
+                        'processor' => [
+                            'cache_ttl' => 60,
+                            'export_format' => 'array',
+                        ],
+                        'doctrine_orm' => [
+                            'mappings' => [
+                                'dummy-id' => 'id',
+                                'dummy-name' => ['property' => 'userName'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertEquals($resourceMetadata, $factory->create('Foo'));
+    }
+
+    /** @test */
+    public function it_returns_without_updating_when_defaults_were_set()
+    {
+        $resourceMetadata = new ResourceMetadata(null, 'My desc', null, null, null, [
+            'rollerworks_search' => [
+                'contexts' => [
+                    'foo' => [
+                        'processor' => [
+                            'export_format' => 'array',
+                        ],
+                        'doctrine_orm' => [
+                            'mappings' => [
+                                'dummy-name' => ['property' => 'userName'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $decoratedProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $decoratedProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
+        $decorated = $decoratedProphecy->reveal();
+
+        $factory = new DefaultConfigurationMetadataFactory($decorated);
+
+        self::assertSame($resourceMetadata, $factory->create('Foo'));
+    }
+
+    /** @test */
+    public function it_returns_without_updating_when_no_search_config_was_set()
+    {
+        $resourceMetadata = new ResourceMetadata(null, 'My desc', null, null, null, [
+            'contexts' => [
+                'foo' => [
+                    'processor' => [
+                        'export_format' => 'array',
+                    ],
+                    'doctrine_orm' => [
+                        'mappings' => [
+                            'dummy-name' => ['property' => 'userName'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $decoratedProphecy = $this->prophesize(ResourceMetadataFactoryInterface::class);
+        $decoratedProphecy->create('Foo')->willReturn($resourceMetadata)->shouldBeCalled();
+        $decorated = $decoratedProphecy->reveal();
+
+        $factory = new DefaultConfigurationMetadataFactory($decorated);
+
+        self::assertSame($resourceMetadata, $factory->create('Foo'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Instead of using the FieldSet as configuration reference the metadata now works with contexts.
Context `_any` is used when no context is provided by a custom listener.

A context is resolved in the SearchConditionListener and passed trough the system using
the `_api_search_config` Request attribute. Condition processors no longer require the MetadataFactory.

Secondly a `_default` context is introduced that allows to define defaults for all contexts, the configuration of `_default` is merged by the DefaultConfigurationMetadataFactory. So runtime overhad is minimum.

Last, the error reporting is greatly improved and the URL generator will now include all previous _route_params unless they begin with an underscore or param value is an array.

FieldSet building using the Metadata is removed, this would be to limited and was removed from the Core library for this exact reason. Also it would only require more maintenance and increase complexity.