### PR TITLE
Rename `_default` context to `_defaults`

### DIFF
--- a/Metadata-reference.md
+++ b/Metadata-reference.md
@@ -3,7 +3,7 @@ Class:
 ```php
  "rollerworks_search" = {
     "contexts" = {
-        "_default" {
+        "_defaults" {
             # Set defaults, merged with more specific configuration (and _any)
         },
         "ContextName | _any" = { # ContextName is provided using event listeners (request#attributes[_search_context])

--- a/src/Metadata/DefaultConfigurationMetadataFactory.php
+++ b/src/Metadata/DefaultConfigurationMetadataFactory.php
@@ -17,7 +17,7 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 
 /**
- * The DefaultConfigurationMetadataFactory merges the `_default` configuration
+ * The DefaultConfigurationMetadataFactory merges the `_defaults` configuration
  * of the `rollerworks_search` resource attribute to all configs.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
@@ -43,15 +43,15 @@ final class DefaultConfigurationMetadataFactory implements ResourceMetadataFacto
         $resourceMetadata = $this->decorated->create($resourceClass);
         $searchConfig = $resourceMetadata->getAttribute('rollerworks_search');
 
-        if (empty($searchConfig) || empty($searchConfig['contexts']['_default'])) {
+        if (empty($searchConfig) || empty($searchConfig['contexts']['_defaults'])) {
             return $resourceMetadata;
         }
 
         $configurations = $searchConfig['contexts'];
-        unset($configurations['_default']);
+        unset($configurations['_defaults']);
 
         foreach ($configurations as $name => $configuration) {
-            $configurations[$name] = array_replace_recursive($searchConfig['contexts']['_default'], $configuration);
+            $configurations[$name] = array_replace_recursive($searchConfig['contexts']['_defaults'], $configuration);
         }
 
         $attributes = $resourceMetadata->getAttributes();

--- a/tests/Metadata/DefaultConfigurationMetadataFactoryTest.php
+++ b/tests/Metadata/DefaultConfigurationMetadataFactoryTest.php
@@ -26,7 +26,7 @@ final class DefaultConfigurationMetadataFactoryTest extends TestCase
         $resourceMetadata = new ResourceMetadata(null, 'My desc', null, null, null, [
             'rollerworks_search' => [
                 'contexts' => [
-                    '_default' => [
+                    '_defaults' => [
                         'processor' => [
                             'cache_ttl' => 60,
                             'export_format' => 'json',
@@ -81,7 +81,7 @@ final class DefaultConfigurationMetadataFactoryTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_without_updating_when_defaults_were_set()
+    public function it_returns_without_updating_when_no_defaults_were_set()
     {
         $resourceMetadata = new ResourceMetadata(null, 'My desc', null, null, null, [
             'rollerworks_search' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Defaults gives a better meaning that these values are merged.

**Note:** While technically a bug fix, this is also a BC break.
And therefor require a new minor release.