### PR TITLE
Fix bool mismatch between URI input and exported

### DIFF
--- a/src/Processor/ApiSearchProcessor.php
+++ b/src/Processor/ApiSearchProcessor.php
@@ -116,8 +116,11 @@ final class ApiSearchProcessor implements SearchProcessor
 
         $exported = $this->exportFactory->get('array')->exportCondition($payload->searchCondition);
         $payload->searchCode = http_build_query($exported);
-        $payload->exportedCondition = $exported;
         $payload->exportedFormat = 'array';
+
+        // Parse query-string back into a array to by-pass bool conversion in URI
+        // https://github.com/rollerworks/search/issues/177
+        parse_str($payload->searchCode, $payload->exportedCondition);
     }
 
     private function storeCache(ProcessorConfig $config, SearchPayload $payload): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Fixes https://github.com/rollerworks/search/issues/177
| License       | MIT
| Doc PR        | 

The provided URI search query uses strings int’s for boolean but the exported Condition uses real boolean’s causing a mismatch and an endless redirect as the code never equals.

This is fixed by re-parsing the searchCode (query-string) as an array and using that one instead.